### PR TITLE
Fix future type to allow returning null in catchError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.2.3
 
-- Fix tasks with non-nullable return types when an error is thrown.
+- Fix tasks with non-nullable return types when an error is thrown. ([#4](https://github.com/agilord/executor/pull/4) by [davidmartos96](https://github.com/davidmartos96))
 
 ## 2.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.2.3
+
+- Fix tasks with non-nullable return types when an error is thrown.
+
 ## 2.2.2
 
 - Migrated to null safety (by [swdyh](https://github.com/swdyh))

--- a/lib/executor.dart
+++ b/lib/executor.dart
@@ -86,7 +86,7 @@ abstract class Executor {
   /// complete.
   ///
   /// If [withWaiting] is set, it will include the waiting tasks too.
-  Future join({bool withWaiting = false});
+  Future<void> join({bool withWaiting = false});
 
   /// Notifies the listeners about a state change in [Executor], for example:
   /// - one or more tasks have started

--- a/lib/executor.dart
+++ b/lib/executor.dart
@@ -86,7 +86,7 @@ abstract class Executor {
   /// complete.
   ///
   /// If [withWaiting] is set, it will include the waiting tasks too.
-  Future<void> join({bool withWaiting = false});
+  Future<List<Object?>> join({bool withWaiting = false});
 
   /// Notifies the listeners about a state change in [Executor], for example:
   /// - one or more tasks have started

--- a/lib/src/executor_impl.dart
+++ b/lib/src/executor_impl.dart
@@ -122,7 +122,7 @@ class _Executor implements Executor {
   }
 
   @override
-  Future<void> join({bool withWaiting = false}) {
+  Future<List<Object?>> join({bool withWaiting = false}) {
     final futures = <Future<Object?>>[];
     for (final item in _running) {
       futures.add(item.result.future.catchError((_) async => null));
@@ -132,7 +132,7 @@ class _Executor implements Executor {
         futures.add(item.result.future.catchError((_) async => null));
       }
     }
-    if (futures.isEmpty) return Future.value();
+    if (futures.isEmpty) return Future.value([]);
     return Future.wait(futures);
   }
 

--- a/lib/src/executor_impl.dart
+++ b/lib/src/executor_impl.dart
@@ -3,8 +3,8 @@ part of executor;
 class _Executor implements Executor {
   int _concurrency;
   Rate? _rate;
-  final ListQueue<_Item> _waiting = ListQueue<_Item>();
-  final ListQueue<_Item> _running = ListQueue<_Item>();
+  final ListQueue<_Item<Object?>> _waiting = ListQueue<_Item<Object?>>();
+  final ListQueue<_Item<Object?>> _running = ListQueue<_Item<Object?>>();
   final ListQueue<DateTime> _started = ListQueue<DateTime>();
   final StreamController _onChangeController = StreamController.broadcast();
   bool _closing = false;
@@ -49,7 +49,7 @@ class _Executor implements Executor {
   @override
   Future<R> scheduleTask<R>(AsyncTask<R> task) async {
     if (isClosing) throw Exception('Executor doesn\'t accept  tasks.');
-    final item = _Item<R>();
+    final item = _Item<R?>();
     _waiting.add(item);
     _trigger();
     await item.trigger.future;
@@ -68,7 +68,10 @@ class _Executor implements Executor {
     _running.remove(item);
     _trigger();
     item.done.complete();
-    return item.result.future;
+    return await item.result.future
+        // Nullable R is used to allow using catchError with null output, so
+        // we must convert R? into R for the caller
+        .then((v) => v ?? v as R);
   }
 
   @override
@@ -119,8 +122,8 @@ class _Executor implements Executor {
   }
 
   @override
-  Future join({bool withWaiting = false}) {
-    final futures = <Future>[];
+  Future<void> join({bool withWaiting = false}) {
+    final futures = <Future<Object?>>[];
     for (final item in _running) {
       futures.add(item.result.future.catchError((_) async => null));
     }
@@ -186,6 +189,7 @@ class _Executor implements Executor {
 
 class _Item<R> {
   final trigger = Completer();
-  final result = Completer<R>();
+  // Nullable R is used here so that we can return null during catchError
+  final result = Completer<R?>();
   final done = Completer();
 }

--- a/lib/src/executor_impl.dart
+++ b/lib/src/executor_impl.dart
@@ -71,7 +71,7 @@ class _Executor implements Executor {
     return await item.result.future
         // Nullable R is used to allow using catchError with null output, so
         // we must convert R? into R for the caller
-        .then((v) => v ?? v as R);
+        .then((v) => v as R);
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: executor
 description: >
   Executes async tasks with a configurable maximum concurrency and rate.
-version: 2.2.2
+version: 2.2.3
 homepage: https://github.com/agilord/executor
 
 environment:

--- a/test/executor_test.dart
+++ b/test/executor_test.dart
@@ -77,7 +77,12 @@ void main() {
               // We don't want the failed tasks to leak into the dart test
               .ignore();
         }
-        await executor.join(withWaiting: true);
+        final taskResults = await executor.join(withWaiting: true);
+
+        // All the items failed, so they contain null
+        expect(taskResults.length, 10);
+        expect(taskResults, everyElement(null));
+
         await executor.close();
       }
 

--- a/test/executor_test.dart
+++ b/test/executor_test.dart
@@ -79,7 +79,7 @@ void main() {
         }
         final taskResults = await executor.join(withWaiting: true);
 
-        // All the items failed, so they contain null
+        // All the tasks throw, so the output is null
         expect(taskResults.length, 10);
         expect(taskResults, everyElement(null));
 

--- a/test/executor_test.dart
+++ b/test/executor_test.dart
@@ -81,11 +81,11 @@ void main() {
         await executor.close();
       }
 
-      test('Nullable return type)', () async {
+      test('Nullable return type', () async {
         await testForType<int?>(defaultValue: 1);
       });
 
-      test('Non-nullable return type)', () async {
+      test('Non-nullable return type', () async {
         await testForType<int>(defaultValue: 1);
       });
     });

--- a/test/executor_test.dart
+++ b/test/executor_test.dart
@@ -63,17 +63,31 @@ void main() {
       expect(executor.scheduledCount, 0);
     });
 
-    test('Exceptions do not block further execution.', () async {
-      final executor = Executor(concurrency: 2);
-      for (var i = 0; i < 10; i++) {
-        // ignore: unawaited_futures
-        executor.scheduleTask(() async {
-          await Future.delayed(Duration(microseconds: i * 10));
-          await Future<Null>.microtask(() => throw Exception());
-        });
+    group('Exceptions do not block further execution', () {
+      Future<void> testForType<T>({required T defaultValue}) async {
+        final executor = Executor(concurrency: 2);
+        for (var i = 0; i < 10; i++) {
+          executor.scheduleTask<T>(() async {
+            await Future.delayed(Duration(microseconds: i * 10));
+            await Future<Null>.microtask(() => throw Exception());
+
+            // Some arbitrary value to match the task type
+            return defaultValue;
+          }) //
+              // We don't want the failed tasks to leak into the dart test
+              .ignore();
+        }
+        await executor.join(withWaiting: true);
+        await executor.close();
       }
-      await executor.join(withWaiting: true);
-      await executor.close();
+
+      test('Nullable return type)', () async {
+        await testForType<int?>(defaultValue: 1);
+      });
+
+      test('Non-nullable return type)', () async {
+        await testForType<int>(defaultValue: 1);
+      });
     });
 
     test('Rate limiting', () async {


### PR DESCRIPTION
Hello!
I've recently encountered with an issue when awaiting the `close` of a `PostgresPool`
After some debugging I found that the issue comes from the usage of `catchError` + `null` return when joining the tasks.
https://github.com/agilord/executor/blob/833ce153efd94b87028afa3784910161face60d1/lib/src/executor_impl.dart#L129

The type of the task is R, but that doesn't mean it can accept null as a type, so it fails at runtime with the following error.
`Invalid argument(s) (onError): The error handler of Future.catchError must return a value of the future's type`

Here is a test that breaks in current version of `executor`.

```dart
        final executor = Executor(concurrency: 2);
        for (var i = 0; i < 10; i++) {
          // Non-nullable int as a type
          // This mimics the usage of executor in postgres_pool, 
          // which are also non-nullable types
          executor.scheduleTask<int>(() async {
            await Future.delayed(Duration(microseconds: i * 10));
            await Future<Null>.microtask(() => throw Exception());

            // Some arbitrary value to match the task type
            return 1;
          });
        }
        await executor.join(withWaiting: true);
        await executor.close();
```

This PR adds a few tests to check for non-null and nullable task types behavior and fixes the issue.