### PR TITLE
DON'T MERGE Failing test

### DIFF
--- a/lib/executor.dart
+++ b/lib/executor.dart
@@ -86,7 +86,7 @@ abstract class Executor {
   /// complete.
   ///
   /// If [withWaiting] is set, it will include the waiting tasks too.
-  Future join({bool withWaiting = false});
+  Future<List<Object?>> join({bool withWaiting = false});
 
   /// Notifies the listeners about a state change in [Executor], for example:
   /// - one or more tasks have started

--- a/lib/src/executor_impl.dart
+++ b/lib/src/executor_impl.dart
@@ -119,8 +119,8 @@ class _Executor implements Executor {
   }
 
   @override
-  Future join({bool withWaiting = false}) {
-    final futures = <Future>[];
+  Future<List<Object?>> join({bool withWaiting = false}) {
+    final futures = <Future<Object?>>[];
     for (final item in _running) {
       futures.add(item.result.future.catchError((_) async => null));
     }
@@ -129,7 +129,7 @@ class _Executor implements Executor {
         futures.add(item.result.future.catchError((_) async => null));
       }
     }
-    if (futures.isEmpty) return Future.value();
+    if (futures.isEmpty) return Future.value([]);
     return Future.wait(futures);
   }
 

--- a/test/executor_test.dart
+++ b/test/executor_test.dart
@@ -63,17 +63,31 @@ void main() {
       expect(executor.scheduledCount, 0);
     });
 
-    test('Exceptions do not block further execution.', () async {
-      final executor = Executor(concurrency: 2);
-      for (var i = 0; i < 10; i++) {
-        // ignore: unawaited_futures
-        executor.scheduleTask(() async {
-          await Future.delayed(Duration(microseconds: i * 10));
-          await Future<Null>.microtask(() => throw Exception());
-        });
+    group('Exceptions do not block further execution', () {
+      Future<void> testForType<T>({required T defaultValue}) async {
+        final executor = Executor(concurrency: 2);
+        for (var i = 0; i < 10; i++) {
+          executor.scheduleTask<T>(() async {
+            await Future.delayed(Duration(microseconds: i * 10));
+            await Future<Null>.microtask(() => throw Exception());
+
+            // Some arbitrary value to match the task type
+            return defaultValue;
+          }) //
+              // We don't want the failed tasks to leak into the dart test
+              .ignore();
+        }
+        await executor.join(withWaiting: true);
+        await executor.close();
       }
-      await executor.join(withWaiting: true);
-      await executor.close();
+
+      test('Nullable return type)', () async {
+        await testForType<int?>(defaultValue: 1);
+      });
+
+      test('Non-nullable return type)', () async {
+        await testForType<int>(defaultValue: 1);
+      });
     });
 
     test('Rate limiting', () async {


### PR DESCRIPTION
@isoos I've created a different draft PR just with the failing test + the typed `join` so that you can try it out locally.

Typing the `join` output doesn't seem to fix the issue with non-nullable tasks that throw.
