### PR TITLE
move task to first

### DIFF
--- a/lib/executor.dart
+++ b/lib/executor.dart
@@ -74,13 +74,16 @@ abstract class Executor {
   /// The total number of tasks scheduled ([runningCount] + [waitingCount]).
   int get scheduledCount;
 
+  /// Move the task with the specified [flag] to the first
+  void moveToFirst(Object flag);
+
   /// Schedules an async task and returns with a future that completes when the
   /// task is finished. Task may not get executed immediately.
-  Future<R> scheduleTask<R>(AsyncTask<R> task);
+  Future<R> scheduleTask<R>(AsyncTask<R> task, {Object? flag});
 
   /// Schedules an async task and returns its stream. The task is considered
   /// running until the stream is closed.
-  Stream<R> scheduleStream<R>(StreamTask<R> task);
+  Stream<R> scheduleStream<R>(StreamTask<R> task, {Object? flag});
 
   /// Returns a [Future] that completes when all currently running tasks
   /// complete.

--- a/lib/executor.dart
+++ b/lib/executor.dart
@@ -75,7 +75,7 @@ abstract class Executor {
   int get scheduledCount;
 
   /// Move the task with the specified [flag] to the first
-  void moveToFirst(Object flag);
+  bool moveToFirst(Object flag);
 
   /// Schedules an async task and returns with a future that completes when the
   /// task is finished. Task may not get executed immediately.

--- a/lib/src/executor_impl.dart
+++ b/lib/src/executor_impl.dart
@@ -50,8 +50,10 @@ class _Executor implements Executor {
   }
 
   @override
-  void moveToFirst(Object flag) {
+  bool moveToFirst(Object flag) {
+    if(_flagItems[flag]?.isEmpty ?? true) return false;
     _flagItems[flag]?.forEach(_moveToFirst);
+    return true;
   }
 
   @override

--- a/lib/src/executor_impl.dart
+++ b/lib/src/executor_impl.dart
@@ -3,10 +3,12 @@ part of executor;
 class _Executor implements Executor {
   int _concurrency;
   Rate? _rate;
-  final DoubleLinkedQueue<_Item<Object?>> _waiting = DoubleLinkedQueue<_Item<Object?>>();
+  final DoubleLinkedQueue<_Item<Object?>> _waiting =
+      DoubleLinkedQueue<_Item<Object?>>();
   final ListQueue<_Item<Object?>> _running = ListQueue<_Item<Object?>>();
   final ListQueue<DateTime> _started = ListQueue<DateTime>();
-  final HashMap<Object, List<_Item<Object?>>> _flagItems = HashMap<Object, List<_Item<Object?>>>();
+  final HashMap<Object, List<_Item<Object?>>> _flagItems =
+      HashMap<Object, List<_Item<Object?>>>();
   final StreamController _onChangeController = StreamController.broadcast();
   bool _closing = false;
   Timer? _triggerTimer;
@@ -72,7 +74,8 @@ class _Executor implements Executor {
     _trigger();
     await item.trigger.future;
     if (isClosing) {
-      item.result.completeError(TimeoutException('Executor is closing'), Trace.current(1));
+      item.result.completeError(
+          TimeoutException('Executor is closing'), Trace.current(1));
     } else {
       try {
         final r = await task();
@@ -129,7 +132,10 @@ class _Executor implements Executor {
             complete();
             return null;
           }
-          streamSubscription = stream.listen(streamController.add, onError: streamController.addError, onDone: complete, cancelOnError: true);
+          streamSubscription = stream.listen(streamController.add,
+              onError: streamController.addError,
+              onDone: complete,
+              cancelOnError: true);
         } catch (e, st) {
           completeWithError(e, st);
         }
@@ -202,7 +208,9 @@ class _Executor implements Executor {
       _running.add(item);
       item.done.future.whenComplete(() {
         _trigger();
-        if (!_closing && _onChangeController.hasListener && !_onChangeController.isClosed) {
+        if (!_closing &&
+            _onChangeController.hasListener &&
+            !_onChangeController.isClosed) {
           _onChangeController.add(null);
         }
       });

--- a/test/executor_test.dart
+++ b/test/executor_test.dart
@@ -7,7 +7,8 @@ void main() {
   group('AsyncTask', () {
     test('does not run after closing', () async {
       final executor = Executor();
-      final resultFuture = executor.scheduleTask(() => Future.microtask(() => 12));
+      final resultFuture =
+          executor.scheduleTask(() => Future.microtask(() => 12));
 
       await Future.delayed(Duration.zero);
       await executor.close();


### PR DESCRIPTION
The ```_waiting``` property is changed from ```ListQueue<_Item<Object?>>``` to ```DoubleLinkedQueue<_Item<Object?>>```. This implements the feature of moving a specific task to the first of the queue..